### PR TITLE
More immune regex

### DIFF
--- a/tests/scripted/check-namespace
+++ b/tests/scripted/check-namespace
@@ -10,6 +10,26 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
+
+
+# types
+
+class BlockType:
+    pass
+
+
+IF_MACRO = BlockType()
+HEADER_GUARD = BlockType()
+CODE_BLOCK = BlockType()
+EXTERN = BlockType()
+
+
+class Expectation(NamedTuple):
+    type: BlockType
+    statement: str  # expected end statement
+    name: str  # expected name in comment
+
 
 # global variables
 
@@ -78,15 +98,15 @@ statement_pattern = re.compile(
     # Macro followed by name or comment
     #  With (?P<name>...) you can do a backreference to \name later
     r'^ *# *(?P<named_macro>ifn?def|endif)(( *// *| +)(?P<macro_name>\w+))?|'
-    # Other macros
-    r'^ *# *(?P<macro>include|if|el)|'
+    # Other macros where we don't want the argument
+    r'^ *# *(?P<macro>include|if|el(se|if))|'
 
     # Namespace that contains no other braces needs no end comment
     #  With a (?=lookahead) we can let the "namespace" part be eaten by the parser
     #  but save the braces and their content for later so they can be matched again
     r'^ *namespace *[\w:]*\s*(?={[^{}]*})|'
-    # Start of named namespace, or just a opening brace
-    r'(^ *namespace *(?P<namespace_start>[\w:]+)\s*)?(?P<opening_brace>{)|'
+    # Start of named namespace, extern "C" or just a opening brace
+    r'(^ *(namespace +(?P<namespace>[\w:]+)|(?P<extern>extern *"C"))\s*)?(?P<opening_brace>{)|'
     # End of namespace including comment, or just a closing brace
     r'(?P<closing_brace>})( *// *namespace +(?P<namespace_end>[\w:]+))?|'
 
@@ -115,8 +135,7 @@ for cur_file in files:
             namespace_pattern.search(cur_text) or error(cur_file, None, f'File has no namespace lmms')
 
         header_guard = str(cur_file).endswith('.h')
-        found_start_of_code = False
-        expected_statements = []  # [(statement, argument)]
+        expectations: list[Expectation] = []
 
         if header_guard:
             if not header_guard_pattern.match(cur_text):
@@ -124,39 +143,51 @@ for cur_file in files:
                 header_guard = False
 
         for m in statement_pattern.finditer(cur_text):
-            macro = m.group('macro') or m.group('named_macro') or m.group('short_macro') or ''
-            name = m.group('macro_name') or m.group('namespace_start') or m.group('namespace_end') or ''
-            brace = m.group('opening_brace') or m.group('closing_brace') or ''
-
-            if not macro and not brace:
+            # Find the matched regex group
+            statement = m.group('opening_brace') or m.group('closing_brace')
+            if not statement:
+                statement = '#' + (m.group('macro') or m.group('named_macro') or m.group('short_macro') or '')
+            if not statement:
                 continue
-            elif brace:
-                found_start_of_code = True
 
-            if macro == 'include' and found_start_of_code:
-                error(cur_file, m, '#include after beginning of C++ code')
-            elif macro.startswith('if'):
-                # Require no end comment for the header guard
-                expected_statements.append(('endif', name if not header_guard else None))
+            # Start statements
+            if statement == '{':
+                etype = EXTERN if m.group('extern') else CODE_BLOCK
+                expectations.append(Expectation(etype, '}', m.group('namespace')))
+            elif statement.startswith('#if'):
+                etype = HEADER_GUARD if header_guard else IF_MACRO
+                expectations.append(Expectation(etype, '#endif', m.group('macro_name')))
                 header_guard = False
-            elif macro == 'el':
-                exp = expected_statements[-1][0]
-                if exp != 'endif':
-                    error(cur_file, m, f'Expected {exp} before #el')
-            elif macro == 'endif' or brace == '}':
-                if not expected_statements:
-                    error(cur_file, m, f'Unexpected {macro or brace}')
-                    continue
-                exp, expected_name = expected_statements.pop()
-                if (macro or brace) != exp:
-                    error(cur_file, m, f'Expected {exp} before {macro or brace}')
-                elif expected_name and name != expected_name:
-                    error(cur_file, m, f'Missing comment // {"namespace " if brace else ""}{expected_name}')
-            elif brace == '{':
-                expected_statements.append(('}', name))
 
-        for exp, name in reversed(expected_statements):
-            error(cur_file, None, f'Expected {exp} before end of file')
+            # End statements
+            elif statement == '#endif' or statement.startswith('#el') or statement == '}':
+                if not expectations:
+                    error(cur_file, m, f'Unexpected {statement}')
+                    break
+                # Don't pop the expectation for an #else tag, we are still waiting for the #endif
+                if statement.startswith('#el') and expectations[-1].statement == '#endif':
+                    continue
+                exp = expectations.pop()
+                name = m.group('macro_name') or m.group('namespace_end') or ''
+                if statement != exp.statement:
+                    error(cur_file, m, f'Expected {exp.statement} before {statement}')
+                    break
+                # Require no end comment for header guard
+                elif exp.type is HEADER_GUARD and not name:
+                    continue
+                elif exp.name and name != exp.name:
+                    comment = 'namespace ' if exp.type is CODE_BLOCK else ''
+                    error(cur_file, m, f'Missing comment // {comment}{exp.name}')
+
+            # Extra checks
+            elif statement == '#include':
+                if any(True for e in expectations if e.type is CODE_BLOCK):
+                    error(cur_file, m, '#include inside a code block')
+
+        else:
+            # Leftover expected statements
+            for exp in reversed(expectations):
+                error(cur_file, None, f'Expected {exp.statement} before end of file')
 
 caption('summary')
 

--- a/tests/scripted/check-namespace
+++ b/tests/scripted/check-namespace
@@ -8,6 +8,7 @@
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 # global variables
@@ -61,26 +62,34 @@ exclude_files = re.compile(
 
 files = [Path(f) for f in result.stdout.splitlines() if not exclude_files.search(f)]
 
-statement_pattern = re.compile(
-    # IRRELEVANT STRINGS - by capturing these we prevent them from matching later
-    # Block comment or regular comment (including escaped newlines)
-    r'/[*](.|\n)*?[*]/|//(.*\\\n)*.*|'
-    # Small namespace that doesn't require an end comment
-    r'namespace *[\w:]*\s*{[^{}]*}|'
-    # ifdef of max 30 lines and with no other #if inside
-    r'^ *# *ifn?def(([^#\n]|#(?!if|endif))*\n){,30} *# *endif|'
+# Debug argument
+if len(sys.argv) > 1:
+    files = [Path(arg) for arg in sys.argv[1:]]
 
-    # INTERESTING STRINGS - with (?P<name>...) you can do a backreference to \name later
+statement_pattern = re.compile(
+    # Capture comments first to prevent them from matching any other regex
+    #  Include next line if line ends with backslash
+    r'/[*](.|\n)*?[*]/|//(.*\\\n)*.*|'
+
+    # Macro with <30 lines and no other #if inside needs no end comment
+    #  Match here to prevent from matching next regex
+    #  With a (?!negative lookahead) we can allow all # except the ones followed by "if"
+    r'^ *# *(?P<short_macro>ifn?def)(?=(([^#\n]|#(?!if|endif))*\n){,30} *# *endif)|'
     # Macro followed by name or comment
+    #  With (?P<name>...) you can do a backreference to \name later
     r'^ *# *(?P<named_macro>ifn?def|endif)(( *// *| +)(?P<macro_name>\w+))?|'
     # Other macros
     r'^ *# *(?P<macro>include|if|el)|'
+
+    # Namespace that contains no other braces needs no end comment
+    #  With a (?=lookahead) we can let the "namespace" part be eaten by the parser
+    #  but save the braces and their content for later so they can be matched again
+    r'namespace *[\w:]*\s*(?={[^{}]*})|'
     # Start of named namespace, or just a opening brace
     r'(^ *namespace *(?P<namespace_start>[\w:]+)\s*)?(?P<opening_brace>{)|'
     # End of namespace including comment, or just a closing brace
     r'(?P<closing_brace>})( *// *namespace +(?P<namespace_end>[\w:]+))?|'
 
-    # MODIFIERS
     # In all the regexes above match both tab and space when a space is used
     r''.replace(' ', r'[\t ]'),
     # Make ^ match on every line, not just beginning of file
@@ -115,7 +124,7 @@ for cur_file in files:
                 header_guard = False
 
         for m in statement_pattern.finditer(cur_text):
-            macro = m.group('macro') or m.group('named_macro') or ''
+            macro = m.group('macro') or m.group('named_macro') or m.group('short_macro') or ''
             name = m.group('macro_name') or m.group('namespace_start') or m.group('namespace_end') or ''
             brace = m.group('opening_brace') or m.group('closing_brace') or ''
 
@@ -135,6 +144,9 @@ for cur_file in files:
                 if exp != 'endif':
                     error(cur_file, m, f'Expected {exp} before #el')
             elif macro == 'endif' or brace == '}':
+                if not expected_statements:
+                    error(cur_file, m, f'Unexpected {macro or brace}')
+                    continue
                 exp, expected_name = expected_statements.pop()
                 if (macro or brace) != exp:
                     error(cur_file, m, f'Expected {exp} before {macro or brace}')
@@ -142,6 +154,9 @@ for cur_file in files:
                     error(cur_file, m, f'Missing comment // {"namespace " if brace else ""}{expected_name}')
             elif brace == '{':
                 expected_statements.append(('}', name))
+
+        for exp, name in reversed(expected_statements):
+            error(cur_file, None, f'Expected {exp} before end of file')
 
 caption('summary')
 

--- a/tests/scripted/check-namespace
+++ b/tests/scripted/check-namespace
@@ -84,7 +84,7 @@ statement_pattern = re.compile(
     # Namespace that contains no other braces needs no end comment
     #  With a (?=lookahead) we can let the "namespace" part be eaten by the parser
     #  but save the braces and their content for later so they can be matched again
-    r'namespace *[\w:]*\s*(?={[^{}]*})|'
+    r'^ *namespace *[\w:]*\s*(?={[^{}]*})|'
     # Start of named namespace, or just a opening brace
     r'(^ *namespace *(?P<namespace_start>[\w:]+)\s*)?(?P<opening_brace>{)|'
     # End of namespace including comment, or just a closing brace

--- a/tests/scripted/check-namespace
+++ b/tests/scripted/check-namespace
@@ -135,7 +135,7 @@ for cur_file in files:
             namespace_pattern.search(cur_text) or error(cur_file, None, f'File has no namespace lmms')
 
         header_guard = str(cur_file).endswith('.h')
-        expectations: list[Expectation] = []
+        expectations = []  # type: list[Expectation]
 
         if header_guard:
             if not header_guard_pattern.match(cur_text):

--- a/tests/scripted/check-namespace
+++ b/tests/scripted/check-namespace
@@ -108,7 +108,7 @@ statement_pattern = re.compile(
     # Start of named namespace, extern "C" or just a opening brace
     r'(^ *(namespace +(?P<namespace>[\w:]+)|(?P<extern>extern *"C"))\s*)?(?P<opening_brace>{)|'
     # End of namespace including comment, or just a closing brace
-    r'(?P<closing_brace>})( *// *namespace +(?P<namespace_end>[\w:]+))?|'
+    r'(?P<closing_brace>})( *// *namespace +(?P<namespace_end>[\w:]+))?'
 
     # In all the regexes above match both tab and space when a space is used
     r''.replace(' ', r'[\t ]'),

--- a/tests/scripted/verify
+++ b/tests/scripted/verify
@@ -159,47 +159,76 @@ with tempfile.TemporaryDirectory() as tmpdir:
 		test.expect('Error: debian/copyright: Glob/Path does not exist: NonExistent')
 		test.expect('1 errors')
 
-	# minimal working example
 	with ScriptTest(check_namespace) as test:
+		# minimal working example
 		test.run(0)  # exitcode 0 - no errors expected
 		test.expect('0 errors')
 
-	with ScriptTest(check_namespace) as test:
-		create_file('src/core/NoNamespace.cpp', '')
+		create_file('01_OddBraceWithinMacro.cpp', '''
+					#if HAS_EVEN_BRACES
+						namespace lmms {}
+					#endif
+					namespace lmms {
+					#if HAS_ODD_BRACE
+					}
+					#endif
+					''')
+		create_file('02_IncludeInCodeBlock.cpp', '''
+					#include <good>
+					extern "C" {
+						#include "alright.c"
+					}
+					namespace lmms {
+						#include <bad>
+					}
+					''')
+		create_file('03_MacroComments.h', '''
+					#ifndef HEADER_GUARD_NEEDS_NO_COMMENT
+					#define HEADER_GUARD_NEEDS_NO_COMMENT
+						#ifdef HAS_NESTED_NEEDS_COMMENT
+							#ifdef SHORT_NO_NESTED_NEEDS_NO_COMMENT
+								namespace lmms {}
+							#endif
+						#endif
+						#ifdef HAS_COMMENT
+							#ifdef SHORT_NO_NESTED_NEEDS_NO_COMMENT
+							#else
+							#endif
+						#endif // HAS_COMMENT
+					#endif
+					''')
+		create_file('04_NamespaceComments.cpp', '''
+					namespace lmms {
+						namespace ShortNamespace {
+							class WithDeclarationsOnly;
+						}
+						namespace LongNamespace {
+							class WithDefinition {
+								int x;
+							};
+						}
+					} // namespace lmms
+					''')
+		create_file('05_NoHeaderGuard.h', '''
+					#include <cstdio>
+					namespace lmms {}
+					''')
+		create_file('06_PragmaButNoLmms.h', '''
+					// should not cause header guard warning
+					#pragma once
+					namespace not_lmms {}
+					''')
 		test.run()
-		test.expect('Error: src/core/NoNamespace.cpp: File has no namespace lmms')
-		test.expect('1 errors')
-	if False:
-		with ScriptTest(check_namespace) as test:
-			create_file('src/core/Model.cpp', 'namespace lmms {\n\n} // namespace lmm')
-			test.run()
-			test.expect('Error: src/core/Model.cpp: namespace/macro ("lmms") does not match end ("lmm")')
-			test.expect('1 errors')
+		test.expect('6 errors')
+		test.expect('''
+Error: 01_OddBraceWithinMacro.cpp:7: Expected #endif before }
+Error: 02_IncludeInCodeBlock.cpp:7: #include inside a code block
+Error: 03_MacroComments.h:8: Missing comment // HAS_NESTED_NEEDS_COMMENT
+Error: 04_NamespaceComments.cpp:10: Missing comment // namespace LongNamespace
+Error: 05_NoHeaderGuard.h: First statement should be header guard
+Error: 06_PragmaButNoLmms.h: File has no namespace lmms
+''')
 
-		with ScriptTest(check_namespace) as test:
-			create_file('src/core/Model.cpp', '#ifdef LMMS_HAVE_LV2\nnamespace lmms {}\n#endif // LMMS_HAVE_LV')
-			test.run()
-			test.expect('Error: src/core/Model.cpp: namespace/macro ("LMMS_HAVE_LV2") does not match end ("LMMS_HAVE_LV")')
-			test.expect('1 errors')
-
-		with ScriptTest(check_namespace) as test:
-			create_file('include/Model.h', '#ifndef MODEL_H\n#define MODEL_H\nnamespace lmms {}\n#endif // MODEL_')
-			test.run()
-			test.expect('Error: include/Model.h: namespace/macro ("MODEL_H") does not match end ("MODEL_")')
-			test.expect('1 errors')
-
-		with ScriptTest(check_namespace) as test:
-			create_file('include/Model.h', '#ifndef MODEL_H\n#define MODEL_H\nnamespace lmms {\n#include "lmms_export.h"\n}#endif // MODEL_H')
-			# "include" inside namespace => user includes file into lmms namespace...
-			test.run()
-			test.expect('Error: include/Model.h: First statement should be header guard')
-			test.expect('1 errors')
-
-	with ScriptTest(check_namespace) as test:
-		create_file('include/Model.h', 'namespace lmms {\n}')
-		test.run()
-		test.expect('Error: include/Model.h: First statement should be header guard')
-		test.expect('1 errors')
 
 # if we made it until here without an exception, all tests have been passed
 print("SUCCESS")


### PR DESCRIPTION
Fixes these bugs and adds ability to debug a single file

```cpp
} // unexpected closing brace causes IndexError

namespace ShortNamespace {
#ifdef // this macro should throw an error but it will never be parsed
// this matches --> }  even if it is a comment
}

{ // unclosed brace does not throw error
```